### PR TITLE
Fix broken links to images

### DIFF
--- a/content/culture-values/mission-patches.mdx
+++ b/content/culture-values/mission-patches.mdx
@@ -15,13 +15,13 @@ This tradition began at NASA in the 1960s. Mission patch stickers are now used i
 
 The different colours focused into a light beam represents different parts of the product coming together.
 
-![Export Service - public beta](/images/Export-Service_Public-beta.png)
+![Export Service - public beta](/digital-trade-handbook/images/Export-Service_Public-beta.png)
 
 ### China Export Listing Service: 13 October 2021
 
 The worker bee represents the huge effort of the team, working together to deliver a service in 10 days. It also refers to honey, one of the non-prescribed goods included in the service.
 
-![China Export Listing Service](/images/China-NPG-Listing-Service.png)
+![China Export Listing Service](/digital-trade-handbook/images/China-NPG-Listing-Service.png)
 
 ### Agriculture Export Service: private beta 30 June 2021
 
@@ -29,7 +29,7 @@ The iceberg represents the significant effort behind the scenes to support this 
 
 The inspiration came from how the delivery manager described the team's effort.
 
-![Export Service - private beta](/images/Export-Service_Private-beta.png)
+![Export Service - private beta](/digital-trade-handbook/images/Export-Service_Private-beta.png)
 
 ### Agriculture Export Service: Export Readiness - scaling to 50
 
@@ -37,7 +37,7 @@ The grown wheat represents services that are ready for release. The growing whea
 
 The inspiration came from the senior designer of the team.
 
-![Export Service - private beta scaling to 50](/images/Export-Service_Private-beta-scale-to-50.png)
+![Export Service - private beta scaling to 50](/digital-trade-handbook/images/Export-Service_Private-beta-scale-to-50.png)
 
 ## Design patches as a team
 

--- a/content/strategy/agile/index.mdx
+++ b/content/strategy/agile/index.mdx
@@ -27,7 +27,7 @@ Rather than waiting 3 or 4 years to deliver a polished, finished product to user
 
 This means users get access to new government services in months, not years. It gives you the ability to gather evidence early on of what is and is not working, before the biggest design and delivery decisions are yet to be made.
 
-We often launch new services as a [Public Beta](../../service-design-delivery-process/beta/#public-beta). This makes clear to users and stakeholders that the service is new and still being improved.
+We often launch new services as a [Public Beta](/service-design-delivery-process/beta#public-beta). This makes clear to users and stakeholders that the service is new and still being improved.
 
 ## Adapt quicker
 

--- a/content/strategy/team-structure/index.mdx
+++ b/content/strategy/team-structure/index.mdx
@@ -53,4 +53,4 @@ Intelligence activities:
 - data and insights
 - supply chain and tractability.
 
-{/* *![Diagram of the 4 service lines and their responsibilities: readiness, clearance, assurance and intelligence.](/images/service-lines.png 'Agricultural export service lines') */}
+{/* *![Diagram of the 4 service lines and their responsibilities: readiness, clearance, assurance and intelligence.](/digital-trade-handbook/images/service-lines.png 'Agricultural export service lines') */}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,9 +13,20 @@ export default function App({ Component, pageProps }: AppProps) {
 					content="width=device-width,initial-scale=1,shrink-to-fit=no,viewport-fit=cover"
 				/>
 				{/* Favicons - https://css-tricks.com/svg-favicons-and-all-the-fun-things-we-can-do-with-them/ */}
-				<link rel="icon" href="/favicon/favicon.ico" sizes="any" />
-				<link rel="icon" href="/favicon/favicon.svg" type="image/svg+xml" />
-				<link rel="manifest" href="/favicon/manifest.webmanifest" />
+				<link
+					rel="icon"
+					href="/digital-trade-handbook/favicon/favicon.ico"
+					sizes="any"
+				/>
+				<link
+					rel="icon"
+					href="/digital-trade-handbook/favicon/favicon.svg"
+					type="image/svg+xml"
+				/>
+				<link
+					rel="manifest"
+					href="/digital-trade-handbook/favicon/manifest.webmanifest"
+				/>
 			</Head>
 			<Component {...pageProps} />
 		</Core>


### PR DESCRIPTION
As the paths of images changed since moving to github pages, links to images are currently broken.